### PR TITLE
[9.x] Introduce a Gate fake double

### DIFF
--- a/src/Illuminate/Auth/Access/DefinesAbilities.php
+++ b/src/Illuminate/Auth/Access/DefinesAbilities.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Auth\Access;
+
+interface DefinesAbilities
+{
+    /**
+     * @return array<string, callable>
+     */
+    public function abilities();
+}

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Support\Testing\Fakes\GateFake;
 
 /**
  * @method static \Illuminate\Auth\Access\Gate guessPolicyNamesUsing(callable $callback)
@@ -23,6 +24,11 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
  * @method static bool has(string $ability)
  * @method static mixed getPolicyFor(object|string $class)
  * @method static mixed raw(string $ability, array|mixed $arguments = [])
+ * @method static \Illuminate\Support\Testing\Fakes\GateFake fail(string $policy, \Illuminate\Auth\Access\Response|\Illuminate\Database\Eloquent\Factories\Sequence|bool|null $value)
+ * @method static \Illuminate\Support\Testing\Fakes\GateFake except(string $policy, ?string $ability)
+ * @method static \Illuminate\Support\Testing\Fakes\GateFake checkOriginalGate()
+ * @method static void assertChecked(string $policy, ?string $ability, ?callable $callback)
+ * @method static void assertCheckedTimes(string $policy, string $ability, int $times)
  *
  * @see \Illuminate\Contracts\Auth\Access\Gate
  */
@@ -36,5 +42,15 @@ class Gate extends Facade
     protected static function getFacadeAccessor()
     {
         return GateContract::class;
+    }
+
+    /**
+     * @return \Illuminate\Support\Testing\Fakes\GateFake
+     */
+    public static function fake()
+    {
+        static::swap($fake = new GateFake(static::getFacadeRoot(), static::$app));
+
+        return $fake;
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/GateFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/GateFake.php
@@ -1,0 +1,425 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Illuminate\Contracts\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\ForwardsCalls;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class GateFake implements Gate
+{
+    use ForwardsCalls;
+
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * The original Gate implementation.
+     *
+     * @var \Illuminate\Contracts\Auth\Access\Gate
+     */
+    protected $gate;
+
+    /**
+     * The abilities to intercept instead of checked.
+     *
+     * @var array
+     */
+    protected $abilitiesToIntercept = [];
+
+    /**
+     * The abilities that have been checked.
+     *
+     * @var array
+     */
+    protected $trackedAbilities = [];
+
+    /**
+     * The policies that have been checked.
+     *
+     * @var array
+     */
+    private $trackedPolicies = [];
+
+    /**
+     * Should we execute the original gate/ability.
+     *
+     * @var bool
+     */
+    protected $checkOriginal = false;
+
+    /**
+     * All the fake policies that have been generated.
+     *
+     * @var array<class-string, string>
+     */
+    private $generatedPolicies = [];
+
+    /**
+     * All policy methods to not fake and execute as normal.
+     *
+     * @var array
+     */
+    private $policiesToIntercept = [];
+
+    public function __construct(Gate $gate, Container $container)
+    {
+        $this->gate = $gate;
+        $this->container = $container;
+
+        $gate->before(function (?Authorizable $user, $ability, $arguments) {
+            if (isset($arguments[0]) && $policy = $this->gate->getPolicyFor($arguments[0])) {
+                $policyClass = get_class($policy);
+                // If it isn't a fake policy then it won't be tracking the usage of the policy,
+                // so we will track it in here.
+                if (! $policy instanceof PolicyFake) {
+                    $this->trackedPolicies[$policyClass][$ability][] = $arguments;
+                }
+
+                if ($policy instanceof PolicyFake) {
+                    $policyClass = $this->gate->policies()[get_class($arguments[0])];
+                    $policyClass = array_flip($this->generatedPolicies)[$policyClass];
+                }
+
+                if (isset($this->policiesToIntercept[$policyClass]) && in_array($ability, $this->policiesToIntercept[$policyClass])) {
+                    return null;
+                }
+
+                return true;
+            }
+
+            $this->trackedAbilities[$ability][] = $arguments;
+
+            if (in_array($ability, array_keys($this->abilitiesToIntercept))) {
+                return null;
+            }
+
+            if ($this->checkOriginal) {
+                $callback = $this->getOriginalGate($ability);
+
+                $callback($user, ...$arguments);
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * @return $this
+     */
+    public function checkOriginalGate()
+    {
+        $this->checkOriginal = true;
+
+        return $this;
+    }
+
+    /**
+     * @param  string $policy
+     * @param  ?string $ability
+     * @return $this
+     */
+    public function except($policy, $ability = null)
+    {
+        if ($this->isPolicy($policy)) {
+            $this->policiesToIntercept[$policy][] = $ability;
+
+            return $this;
+        }
+
+        $this->abilitiesToIntercept[$policy] = true;
+
+        return $this;
+    }
+
+    /**
+     * @param  string $policy
+     * @param  \Illuminate\Auth\Access\Response|Sequence|bool|null $value
+     * @return $this
+     */
+    public function fail($policy, $ability = null, $value = null)
+    {
+        if ($this->isPolicy($policy)) {
+            return $this->failPolicy($policy, $ability, $value);
+        }
+
+        $value = $ability;
+        $this->abilitiesToIntercept[$policy] = $value ?? false;
+        $originalAbility = $this->getOriginalGate($policy);
+        $this->gate->define($policy, function ($user = null, ...$arguments) use ($value, $originalAbility, $policy) {
+            if ($this->checkOriginal) {
+                $originalAbility($user, ...$arguments);
+            }
+
+            $response = $this->abilitiesToIntercept[$policy];
+
+            if ($response instanceof Sequence) {
+                if ($response->count() === 0) {
+                    return false;
+                }
+
+                return $response();
+            }
+
+            return $response;
+        });
+
+        return $this;
+    }
+
+    /**
+     * @param  class-string $policy
+     * @param  string $method
+     * @param  \Illuminate\Auth\Access\Response|Sequence|bool|null $value
+     * @return $this
+     */
+    public function failPolicy($policy, $method, $value)
+    {
+        $policyClass = $this->generatedPolicies[$policy] ?? Str::random() . ':' . $policy;
+        $this->generatedPolicies[$policy] = $policyClass;
+        $this->policiesToIntercept[$policy][] = $method;
+
+        collect($this->gate->policies())
+            ->filter(fn ($key) => $key === $policy)
+            ->keys()
+            ->each(fn ($model) => $this->gate->policy($model, $policyClass));
+
+        if ($this->container->resolved($policyClass)) {
+            $this->container->get($policyClass)
+                ->fail($method, $value)
+                ->checkOriginalAbility($this->checkOriginal);
+
+            return $this;
+        }
+
+        $this->container->instance(
+            $policyClass,
+            (new PolicyFake($this->container->get($policy)))
+                ->fail($method, $value)
+                ->checkOriginalAbility($this->checkOriginal)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the given policy ability or gate has been checked.
+     *
+     * @param  string $policy
+     * @param  ?string $ability
+     * @param  ?callable $callback
+     * @return void
+     */
+    public function assertChecked($policy, $ability = null, $callback = null)
+    {
+        if (is_int($ability) || is_int($callback)) {
+            return $this->assertCheckedTimes($policy, $ability, $callback);
+        }
+
+        PHPUnit::assertTrue($this->checked($policy, $ability, $callback)->isNotEmpty());
+    }
+
+    /**
+     * Assert the given policy ability or gate is called X amount of times.
+     *
+     * @param  string $policy The policy class or the gate name.
+     * @param  string $ability
+     * @param  int $times
+     * @return void
+     */
+    public function assertCheckedTimes($policy, $ability = null, $times = null)
+    {
+        if (is_int($ability)) {
+            $times = $ability;
+            $ability = null;
+        }
+
+        $count = $this->checked($policy, $ability)->count();
+
+        PHPUnit::assertSame(
+            $times, $count,
+            "The expected [{$ability}] ability was checked {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
+     * @param  string $policy
+     * @param  string $ability
+     * @param  ?callable $callback
+     * @return \Illuminate\Support\Collection
+     *
+     */
+    private function checked($policy, $ability, $callback = null)
+    {
+        if ($this->isPolicy($policy)) {
+            $policyInstance = $this->getFakedPolicy($policy);
+            $callback ??= fn () => true;
+
+            // The developer hasn't overridden the policy with ->fail() so we use our
+            // internal cache of tracked policies to check if the ability has been called.
+            if ($policyInstance === null) {
+                return collect($this->trackedPolicies[$policy][$ability])
+                    ->filter(fn ($arguments) => $callback(...$arguments));
+            }
+
+            return $policyInstance->checked($ability, $callback);
+        }
+
+        $callback = $ability ?? fn () => true;
+        $ability = $policy;
+        if (! $this->hasChecked($ability)) {
+            return collect();
+        }
+
+        return collect($this->trackedAbilities[$ability])->filter(fn ($arguments) => $callback(...$arguments));
+    }
+
+    /**
+     * @param  string $ability
+     * @return bool
+     */
+    private function hasChecked($ability)
+    {
+        return isset($this->trackedAbilities[$ability]) && ! empty($this->trackedAbilities[$ability]);
+    }
+
+    /** @inheritDoc */
+    public function has($ability)
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'has', [$ability]);
+    }
+
+    /** @inheritDoc */
+    public function define($ability, $callback)
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'define', [$ability, $callback]);
+    }
+
+    /** @inheritDoc */
+    public function resource($name, $class, array $abilities = null)
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'resource', [$name, $class, $abilities]);
+    }
+
+    /** @inheritDoc */
+    public function policy($class, $policy)
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'policy', [$class, $policy]);
+    }
+
+    /** @inheritDoc */
+    public function before(callable $callback)
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'before', [$callback]);
+    }
+
+    /** @inheritDoc */
+    public function after(callable $callback)
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'after', [$callback]);
+    }
+
+    /** @inheritDoc */
+    public function allows($ability, $arguments = [])
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'allows', [$ability, $arguments]);
+    }
+
+    /** @inheritDoc */
+    public function denies($ability, $arguments = [])
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'denies', [$ability, $arguments]);
+    }
+
+    /** @inheritDoc */
+    public function check($abilities, $arguments = [])
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'check', [$abilities, $arguments]);
+    }
+
+    /** @inheritDoc */
+    public function any($abilities, $arguments = [])
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'any', [$abilities, $arguments]);
+    }
+
+    /** @inheritDoc */
+    public function authorize($ability, $arguments = [])
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'authorize', [$ability, $arguments]);
+    }
+
+    /** @inheritDoc */
+    public function inspect($ability, $arguments = [])
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'inspect', [$ability, $arguments]);
+    }
+
+    /** @inheritDoc */
+    public function raw($ability, $arguments = [])
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'raw', [$ability, $arguments]);
+    }
+
+    /** @inheritDoc */
+    public function getPolicyFor($class)
+    {
+        $this->forwardDecoratedCallTo($this->gate, 'getPolicyFor', [$class]);
+    }
+
+    /** @inheritDoc */
+    public function forUser($user)
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'forUser', []);
+    }
+
+    /** @inheritDoc */
+    public function abilities()
+    {
+        return $this->forwardDecoratedCallTo($this->gate, 'abilities', []);
+    }
+
+    /**
+     * @param  string $gate
+     * @return ?callable
+     */
+    private function getOriginalGate($gate)
+    {
+        return Arr::get($this->gate->abilities(), $gate);
+    }
+
+    /**
+     * @param  string $policy
+     * @return bool
+     */
+    private function isPolicy($policy)
+    {
+        return class_exists($policy) || $this->container->has($policy);
+    }
+
+    /**
+     * Return the PolicyFake for the given policy if it exists.
+     *
+     * @param  string $policy
+     * @return \Illuminate\Support\Testing\Fakes\PolicyFake|string|null
+     */
+    private function getFakedPolicy(string $policy)
+    {
+        $policyClass = $this->generatedPolicies[$policy] ?? null;
+
+        if ($policyClass === null) {
+            return null;
+        }
+
+        return $this->container->get($policyClass);
+    }
+}

--- a/src/Illuminate/Support/Testing/Fakes/PolicyFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PolicyFake.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Illuminate\Auth\Access\DefinesAbilities;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Support\Traits\ForwardsCalls;
+use ReflectionClass;
+
+class PolicyFake implements DefinesAbilities
+{
+    use ForwardsCalls;
+
+    /**
+     * @var mixed
+     */
+    private $originalPolicy;
+
+    /**
+     * @var array
+     */
+    private $abilitiesToIntercept = [];
+
+    /**
+     * @var bool
+     */
+    private $checkOriginalAbility = false;
+
+    /**
+     * @var array
+     */
+    private $trackedAbilities = [];
+
+    public function __construct($originalPolicy)
+    {
+        $this->originalPolicy = $originalPolicy;
+    }
+
+    /**
+     * @param  bool $checkOriginalAbility
+     * @return $this
+     */
+    public function checkOriginalAbility($checkOriginalAbility = true)
+    {
+        $this->checkOriginalAbility = $checkOriginalAbility;
+
+        return $this;
+    }
+
+    /**
+     * @param  string $ability
+     * @param  \Illuminate\Auth\Access\Response|Sequence|null $value
+     * @return $this
+     */
+    public function fail(string $ability, $value = null)
+    {
+        $this->abilitiesToIntercept[$ability] = $value ?? false;
+
+        return $this;
+    }
+
+    public function checked($ability, $callback = null)
+    {
+        if (! $this->hasChecked($ability)) {
+            return collect();
+        }
+
+        $callback ??= fn () => true;
+
+        return collect($this->trackedAbilities[$ability])->filter(fn ($arguments) => $callback(...$arguments));
+    }
+
+    /**
+     * Returns the policy that is being decorated.
+     *
+     * @return mixed
+     */
+    public function getOriginalPolicy()
+    {
+        return $this->originalPolicy;
+    }
+
+    /**
+     * @param  string $ability
+     * @param  array $arguments
+     * @return mixed
+     */
+    public function __call($ability, $arguments)
+    {
+        $this->trackedAbilities[$ability][] = $arguments;
+
+        if (in_array($ability, array_keys($this->abilitiesToIntercept))) {
+            if ($this->checkOriginalAbility) {
+                $this->forwardCallTo($this->originalPolicy, $ability, $arguments);
+            }
+
+            $response = $this->abilitiesToIntercept[$ability];
+
+            if ($response instanceof Sequence) {
+                if ($response->count() === 0) {
+                    return false;
+                }
+
+                return $response();
+            }
+
+            return $response;
+        }
+
+        return $this->forwardDecoratedCallTo($this->originalPolicy, $ability, $arguments);
+    }
+
+    public function abilities()
+    {
+        return collect((new ReflectionClass($this->originalPolicy))->getMethods())
+            ->keyBy->getName()
+            ->all();
+    }
+
+    /**
+     * @param  string $ability
+     * @return bool
+     */
+    private function hasChecked($ability)
+    {
+        return isset($this->trackedAbilities[$ability]);
+    }
+}

--- a/tests/Support/SupportTestingGateFakeTest.php
+++ b/tests/Support/SupportTestingGateFakeTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Support\Testing\Fakes\GateFake;
+use Mockery as m;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+class SupportTestingGateFakeTest extends TestCase
+{
+    /** @var \Illuminate\Support\Testing\Fakes\GateFake */
+    protected $fake;
+
+    /** @var \Illuminate\Auth\Access\Gate */
+    protected $originalGate;
+
+    /**
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalGate = new Gate($this->container = new Container(), fn () => null);
+        $this->fake = new GateFake($this->originalGate, $this->container);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testAllowsByDefault()
+    {
+        $response = $this->fake->allows('example');
+        $this->assertTrue($response);
+
+        $this->fake->fail('example');
+        $response = $this->fake->allows('example');
+        $this->assertFalse($response);
+    }
+
+    public function testDeniesFailsByDefault()
+    {
+        $response = $this->fake->denies('example');
+        $this->assertFalse($response);
+
+        $this->fake->fail('example');
+        $response = $this->fake->denies('example');
+        $this->assertTrue($response);
+    }
+
+    public function testCanProvideSequenceToFail()
+    {
+        $this->fake->fail('example', new Sequence(false, false, true));
+        $response = $this->fake->allows('example');
+        $this->assertFalse($response);
+
+        $response = $this->fake->allows('example');
+        $this->assertFalse($response);
+
+        $response = $this->fake->allows('example');
+        $this->assertTrue($response);
+    }
+
+    public function testWillCheckOriginalGateIfSpecified()
+    {
+        $hasBeenCalled = false;
+        $this->originalGate->define('example', function (User $user = null) use (&$hasBeenCalled) {
+            $hasBeenCalled = true;
+        });
+
+        $this->fake->checkOriginalGate()->allows('example');
+
+        $this->assertTrue($hasBeenCalled);
+    }
+
+    public function testProvideResponseObjectAsResponse()
+    {
+        $this->fake->fail('example', Response::denyAsNotFound());
+
+        $result = $this->fake->allows('example');
+
+        $this->assertFalse($result);
+    }
+
+    public function testCanExcludeGateFromFake()
+    {
+        $this->originalGate->define('example', fn (User $user = null) => Response::denyAsNotFound());
+        $this->fake->except('example');
+
+        $response = $this->fake->raw('example');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(404, $response->status());
+    }
+
+    public function testCanExcludePolicyFromFake()
+    {
+        $this->originalGate->policy(ModelStub::class, PolicyStub::class);
+        $this->fake->except(PolicyStub::class, 'willFail');
+
+        $response = $this->fake->raw('willFail', new ModelStub());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(404, $response->status());
+    }
+
+    public function testCanAssertGateHasBeenCalled()
+    {
+        $this->fake->allows('example');
+
+        $this->fake->assertChecked('example');
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->fake->assertChecked('not-called');
+    }
+
+    public function testCanAssertGateHasBeenCalledWithArguments()
+    {
+        $this->fake->allows('example', 'test');
+        $wasCalled = false;
+
+        $this->fake->assertChecked('example', function ($argumentOne) use (&$wasCalled) {
+            $this->assertEquals('test', $argumentOne);
+            $wasCalled = true;
+
+            return $argumentOne === 'test';
+        });
+
+        $this->assertTrue($wasCalled, 'The callback was not called');
+    }
+
+    public function testCanAssertGateHasBeenCalledAnAmountOfTimes()
+    {
+        $this->fake->allows('example', 'test');
+        $this->fake->allows('example');
+
+        $this->fake->assertCheckedTimes('example', 2);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->fake->assertCheckedTimes('example', 4);
+    }
+
+    public function testCanFailAPolicy()
+    {
+        $this->originalGate->policy(ModelStub::class, PolicyStub::class);
+
+        $result = $this->fake->allows('update', new ModelStub());
+        $this->assertTrue($result);
+
+        $this->fake->fail(PolicyStub::class, 'update');
+
+        $result = $this->fake->allows('update', new ModelStub());
+        $this->assertFalse($result);
+    }
+
+    public function testCanFailAPolicyWithCustomResponse()
+    {
+        $this->originalGate->policy(ModelStub::class, PolicyStub::class);
+
+        $this->fake->fail(PolicyStub::class, 'update', Response::denyAsNotFound());
+
+        $result = $this->fake->raw('update', new ModelStub());
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(404, $result->status());
+    }
+
+    public function testCanCheckOriginalAbilityInPolicy()
+    {
+        $wasCalled = false;
+        $class = new class ($wasCalled) {
+            private $wasCalled;
+
+            public function __construct(&$wasCalled)
+            {
+                $this->wasCalled = &$wasCalled;
+            }
+
+            public function update (?ModelStub $user, ModelStub $model)
+            {
+                $this->wasCalled = true;
+
+                return true;
+            }
+        };
+
+        $this->container->instance('FakePolicy', $class);
+        $this->originalGate->policy(ModelStub::class, 'FakePolicy');
+
+        $this->fake->checkOriginalGate()->fail('FakePolicy', 'update');
+
+        $result = $this->fake->raw('update', new ModelStub());
+
+        $this->assertFalse($result);
+        $this->assertTrue($wasCalled);
+    }
+
+    public function testCanAssertPolicyWasCalled()
+    {
+        $this->originalGate->policy(ModelStub::class, PolicyStub::class);
+
+        $this->fake->allows('update', $stub = new ModelStub());
+        $wasCalled = false;
+
+        $this->fake->assertChecked(PolicyStub::class, 'update', function ($argumentOne) use (&$wasCalled, $stub) {
+            $this->assertEquals($stub, $argumentOne);
+            $wasCalled = true;
+
+            return true;
+        });
+
+        $this->assertTrue($wasCalled, 'The callback was not called');
+    }
+
+    public function testCanAssertPolicyWasCalledANumberOfTimes()
+    {
+        $this->originalGate->policy(ModelStub::class, PolicyStub::class);
+
+        $this->fake->allows('update', $stub = new ModelStub());
+
+        $this->fake->assertCheckedTimes(PolicyStub::class, 'update', 1);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->fake->assertCheckedTimes(PolicyStub::class, 'update', 2);
+    }
+}
+
+class PolicyStub
+{
+    public function update(?ModelStub $user, ModelStub $model)
+    {
+        return true;
+    }
+
+    public function willFail(?ModelStub $user, ModelStub $model)
+    {
+        return Response::denyAsNotFound();
+    }
+}
+
+class ModelStub {}


### PR DESCRIPTION
This adds the ability to allow you to fake out calls to the `Gate` so that you can easily bypass authorisation checks in your tests.

# Problem
Over the last months we have been moving our self made authorisation system across to use Laravel Gates. While going through our existing code and updating we found that being able to mock/ignore certain gates didn't have the cleanest experience. 

For example if we have a Gate defined for checking user has access to an account and we want to ignore it then we would have to do the below.

```php
Gate::before(fn (User $user, $ability) => $ability !== 'canAccessAccount');
```  

# Proposal

To hopefully improve developer's experience and give developers control and assertions around their Gates in their tests this  implements a Gate fake object into Laravel.

To fake out the Gates you run a similar function to all the other fakes within the system `Gate::fake()`. This swaps the default implementation with the fake one. From there all checks to any gate will return true as the response. 

## Failing a Gate

To fail a gate you simply call `fail()` on the Gate facade after you have called `fake()`. This by default will return false as the response to the Gate.

### Possible responses

You can provide a few different responses to the fail method on how you want your gate to fail. These are a Boolean, Response or a Sequence of the previous two.

```php
Gate::fake();

// Boolean
Gate::fail('canAccessAccount', false);

// Response
Gate::fail('canAccessAccount', Response::denyAsNotFound());

// Sequence
Gate::fail('canAccessAccount', new Sequence([false, Response::denyAsNotFound(), true));
```

## Failing a Policy

Very similar to failing a Gate you can perform all the same actions for a Policy. However you need to provide the Policy and the "ability" you want to fake. e.g.

```php
Gate::fake();

Gate::fail(UserPolicy, 'update', false);
```

## Assertions

We've added a couple of assertions to start this off but this is by no means an extensive list of assertions. We kept this simple so that we can organically grow what assertions are needed by the community. 

### `assertChecked`

This allows you to assert that the give gate or policy ability has been ran, you can also provide a closure to this function to perform a more detail assertion of the checks that have been made. Very similarly behaviour to the `assertDispatched` on the BusFake, this is called for every check that has been made on the gate/policy ability. The arguments passed into the closure are the same arguments that were passed into the `Gate::allows`/`Gate::denies`...etc call.

```php
Gate::fake();

// Run user code

Gate::assertChecked('accessAccount');

Gate::assertChecked('accessAccount', function (Account $account) {
    return $account->name === 'Example';
});
```

### `assertCheckedTimes`

Again similar to the Bus fake's `assertDispatchedTimes` this behaves like `assertChecked` however allows you to specify the number of times that check should of been called. 

## Calling the original method

We found In some instances you still want to execute the original gate/policy ability as it might trigger side effects or perform some DB check that you were relying on. In this use case we have provided a method to execute the original method as well as allowing a custom response.

```php
Gate::checkOriginalGate();
```

## Not faking certain gates

Final feature in this PR is the ability to just allow certain gates/abilities to execute as normal with no modification. To do this you call `except` on the Gate fake to ignore certain methods.

```php
Gate::fake()->except('accessAcount`);
```

## Other Notes

As part of the faking logic we've introduced a PolicyFake object, this is a decorated around the Developer's original policy and helps track any calls made to the specific policy. However we hit against a problem that because we are using `__call` to forward on the call to the original policy Laravel was unable to determine the parameters the faked policy abilities had. To get around the Reflection parameter checking on Policy functions we've implemented a new interface that requires you to return all the abilities that a policy requires. These "abilities" are just an array of `ReflectionFunctionAbstract`'s that Laravel can then use to determine if the ability can be ran as a guest and has a user parameter.

I felt this was a clean way to get around this problem and also provided developers was for them to provide abilities for their policies where they might being doing similar things.

Any questions or feedback is greatly appreciated. Thanks.